### PR TITLE
Update semaec4.0.bb with latest verified commit tag from sema-linux-ec repo

### DIFF
--- a/recipes-sema/sema/semaec4.0.bb
+++ b/recipes-sema/sema/semaec4.0.bb
@@ -11,7 +11,7 @@ inherit module
 DEPENDS += "  util-linux util-linux-libuuid"
 
 SRCBRANCH = "sema-ec"
-SRCREV = "2fa426648805676ac815ac764b651e05d1a65cb2"
+SRCREV = "43bea9593a6147536f935a92b1b08a87d7ed486f"
 SRC_URI = "git://github.com/ADLINK/sema-linux.git;branch=${SRCBRANCH};protocol=http \
            "
 


### PR DESCRIPTION
Updated the recipes-sema/sema/semaec4.0.bb file to reference the latest verified commit tag from the ADLINK/sema-linux-ec repository.